### PR TITLE
Refine the worker-pool post and home-page presentation

### DIFF
--- a/assets/css/02-tokens.css
+++ b/assets/css/02-tokens.css
@@ -62,6 +62,7 @@
     --fs-2xs: 0.72rem; /* 12px — eyebrow labels, date / category */
     --fs-xs: 0.8rem; /* 13.6px — archive dates (one step under --fs-sm) */
     --fs-sm: 0.85rem; /* 14px — meta, tables, badges, nav, footer */
+    --fs-code: 0.87rem; /* 14.8px — fenced code */
     --fs-md: 0.9rem; /* 15px — toc, summary, excerpts, h5 / h6 */
     --fs-base: 1rem; /* 17px — body, h4 */
     --fs-lg: 1.1rem; /* 19px — site title */

--- a/assets/css/05-components.css
+++ b/assets/css/05-components.css
@@ -372,7 +372,7 @@
 
   pre code {
     padding: 0;
-    font-size: var(--fs-sm);
+    font-size: var(--fs-code);
     background: none;
     border: none;
     /* code blocks preserve newlines + scroll horizontally — don't inherit the inline

--- a/assets/js/hero-rain.js
+++ b/assets/js/hero-rain.js
@@ -55,7 +55,7 @@
     d.len = 8 + Math.floor(Math.random() * c.rows * 0.42)
     // pick a fall rate in css px/s, then convert to this column's rows/s so
     // small blocks don't crawl next to big ones
-    d.speed = ((16 + Math.random() * 52) * dpr) / c.size
+    d.speed = ((8 + Math.random() * 26) * dpr) / c.size
     d.alpha = 0.24 + Math.random() * 0.44
     // short re-entry gap only — a long one leaves visible holes in the field
     d.head = seeded

--- a/assets/js/hero-rain.js
+++ b/assets/js/hero-rain.js
@@ -55,7 +55,7 @@
     d.len = 8 + Math.floor(Math.random() * c.rows * 0.42)
     // pick a fall rate in css px/s, then convert to this column's rows/s so
     // small blocks don't crawl next to big ones
-    d.speed = ((26 + Math.random() * 88) * dpr) / c.size
+    d.speed = ((16 + Math.random() * 52) * dpr) / c.size
     d.alpha = 0.24 + Math.random() * 0.44
     // short re-entry gap only — a long one leaves visible holes in the field
     d.head = seeded

--- a/content/go/supervised_fire_and_forget.md
+++ b/content/go/supervised_fire_and_forget.md
@@ -157,7 +157,7 @@ func New(capacity, workers int, onPanic func(any)) *Background {
 }
 ```
 
-`workers.Go` is [`WaitGroup.Go`], added in Go 1.25. It starts each worker goroutine and
+`workers.Go` is [WaitGroup.Go], added in Go 1.25. It starts each worker goroutine and
 tracks it in the group in one call. `Stop` waits on that group during shutdown.
 
 Each worker drains the channel:
@@ -375,7 +375,7 @@ The complete implementation is in the [example repo].
 [complete implementation]:
     https://github.com/rednafi/examples/blob/main/supervised-fire-and-forget/internal/bg/bg.go
 
-[`WaitGroup.Go`]:
+[WaitGroup.Go]:
     https://pkg.go.dev/sync#WaitGroup.Go
 
 [example handler]:

--- a/content/go/supervised_fire_and_forget.md
+++ b/content/go/supervised_fire_and_forget.md
@@ -157,8 +157,8 @@ func New(capacity, workers int, onPanic func(any)) *Background {
 }
 ```
 
-`workers.Go` is [WaitGroup.Go], added in Go 1.25. It starts each worker goroutine and
-tracks it in the group in one call. `Stop` waits on that group during shutdown.
+`workers.Go` is [WaitGroup.Go], added in Go 1.25. It starts each worker goroutine and tracks
+it in the group in one call. `Stop` waits on that group during shutdown.
 
 Each worker drains the channel:
 

--- a/content/go/supervised_fire_and_forget.md
+++ b/content/go/supervised_fire_and_forget.md
@@ -101,7 +101,7 @@ close(tasks)
 Each receive loop runs one task at a time, so four workers mean at most four tasks run at
 once. The buffer holds 64 pending closures. Once it fills, the send blocks until a worker
 receives a task. Closing the channel ends the receive loops. The workers drain whatever is
-left in the buffer and exit.
+left in the buffer and exit (not shown here).
 
 ## A real pool needs more than a channel
 


### PR DESCRIPTION
## Summary

- clarify the simplified worker-pool shutdown boundary
- keep linked identifiers and fenced-code typography consistent
- slow the home-page rain uniformly on mobile and desktop

## Validation

- `make test`

Co-authored-by: Codex <noreply@openai.com>